### PR TITLE
feat: support custom component jump and doc rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # vscode-vue-jumper
 
-vue文件跳转到文件定义支持。
+vue 文件跳转到文件定义支持。
 
 ![](./images/usage-demo.gif)
 
@@ -17,27 +17,26 @@ vue文件跳转到文件定义支持。
 支持大驼峰组件、中划线组件。
 
 ```html
-<my-component></my-component>
-<MyComponent></MyComponent>
+<my-component></my-component> <MyComponent></MyComponent>
 ```
 
-## 2. 支持import相对路径文件跳转
+## 2. 支持 import 相对路径文件跳转
 
 ```js
 import MyComponent form '../../component/MyComponent'
 import MyComponent2 form '../../component/MyComponent2.vue'
 ```
 
-## 3. 支持import别名路径文件跳转
+## 3. 支持 import 别名路径文件跳转
 
-import别名路径就是在vue.config.js，也就是在webpack中配置了 `alias` 别名
+import 别名路径就是在 vue.config.js，也就是在 webpack 中配置了 `alias` 别名
 
 ```js
 // vue.config.js
 export default {
-    chainWebpack: config => {
-        config.resolve.alias.set('@$', resolve('src'))
-    }
+  chainWebpack: (config) => {
+    config.resolve.alias.set('@$', resolve('src'))
+  }
 }
 ```
 
@@ -49,38 +48,38 @@ import MyComponent form '@/component/MyComponent'
 
 ![aliasConfigs](./images/aliasConfigs.png)
 
-## 4. 支持mixins引入组件注册跳转
+## 4. 支持 mixins 引入组件注册跳转
 
 ```html
 <template>
-    <div>
-        <MyComponent />
-    </div>
+  <div>
+    <MyComponent />
+  </div>
 </template>
 
 <script>
-    import mixins from "./mixins";
-    export default {
-        mixins: [mixins],
-        props: {},
-        data() {
-            return {};
-        },
-        components: {},
-    };
+  import mixins from './mixins'
+  export default {
+    mixins: [mixins],
+    props: {},
+    data() {
+      return {}
+    },
+    components: {}
+  }
 </script>
 ```
 
 ```js
 // mixins.js
-import MyComponent from "./modules/MyComponent";
+import MyComponent from './modules/MyComponent'
 export default {
-    data() {
-        return {}
-    },
-    components: {
-        MyComponent
-    }
+  data() {
+    return {}
+  },
+  components: {
+    MyComponent
+  }
 }
 ```
 
@@ -100,51 +99,94 @@ vue.use(PrefixMyComponent) // 组件注册
 
 ```js
 // components/MyComponent/index.js
-import MyComponent from './src/index.vue';
+import MyComponent from './src/index.vue'
 
 /* istanbul ignore next */
-MyComponent.install = function(Vue) {
-    Vue.component(MyComponent.name, MyComponent);
-};
+MyComponent.install = function (Vue) {
+  Vue.component(MyComponent.name, MyComponent)
+}
 
-export default MyComponent;
+export default MyComponent
 ```
 
 ```html
 <!-- components/MyComponent/src/index.vue -->
 <template>
-    <div>MyComponent</div>
+  <div>MyComponent</div>
 </template>
 
 <script>
-    export default {
-        name: 'PrefixMyComponent',
-    }
+  export default {
+    name: 'PrefixMyComponent'
+  }
 </script>
 ```
 
 ```html
 <!-- 使用 -->
 <template>
-    <prefix-my-component>MyComponent</prefix-my-component>
+  <prefix-my-component>MyComponent</prefix-my-component>
 </template>
 
 <script>
-    export default {
-        name: 'PrefixMyComponent',
-    }
+  export default {
+    name: 'PrefixMyComponent'
+  }
 </script>
 ```
 
+## 6. 组件跳转与文档配置
+
+通过 `rules` 配置可以自定义组件的查找规则和文档链接。每条规则可以包含组件前缀匹配、文件查找模式和文档地址：
+
+```json
+"vue-jumper.rules": [
+  {
+    "prefix": "uni-",
+    "docUrl": "https://uniapp.dcloud.net.cn/component/uniui/{name}.html", // hover 时出现的文档地址
+    "searchPattern": {
+      "include": "**/node_modules/@dcloudio/uni-ui/lib/*/$1",
+      "exclude": ""
+    }
+  },
+  {
+    "prefix": "u-",
+    "docUrl": "https://uviewui.com/components/{name}.html",
+    "searchPattern": {
+      "include": "**/node_modules/uview-ui/components/$1",
+      "exclude": ""
+    }
+  },
+  // 默认配置，应放在最后
+  {
+    "prefix": "*",
+    "searchPattern": {
+      "include": "**/$1",
+      "exclude": "**/{node_modules,build,dist}"
+    }
+  }
+]
+```
+
+配置说明：
+
+- `prefix`: 组件前缀，`*` 表示匹配所有未匹配的组件
+- `docUrl`: 组件文档地址，支持 `{name}` 变量替换
+- `searchPattern`: 文件查找模式
+  - `include`: 匹配包含的文件路径
+  - `exclude`: 匹配排除的文件路径
+
+规则匹配按配置顺序进行，未匹配到特定前缀的组件将使用 `prefix: "*"` 的默认规则。
+
 ## 版本
 
-* 2.5.0 新增跳转tsx组件支持
-* 2.4.0 兼容其他写法匹配
-* 2.3.0 修复匹配错误
-* 2.2.0 修复windows兼容问题
-* 2.1.0 新增全局注册带特殊前缀组件跳转支持
-* 2.0.0 新增mixins引入组件注册跳转支持
-* 1.3.0-1.5.0 修复匹配错误
-* 1.2.0 增加组件重命名跳转
-* 1.1.0 支持多workspaceFolders工作区跳转
-* 1.0.0 支持基础跳转
+- 2.5.0 新增跳转 tsx 组件支持
+- 2.4.0 兼容其他写法匹配
+- 2.3.0 修复匹配错误
+- 2.2.0 修复 windows 兼容问题
+- 2.1.0 新增全局注册带特殊前缀组件跳转支持
+- 2.0.0 新增 mixins 引入组件注册跳转支持
+- 1.3.0-1.5.0 修复匹配错误
+- 1.2.0 增加组件重命名跳转
+- 1.1.0 支持多 workspaceFolders 工作区跳转
+- 1.0.0 支持基础跳转

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue-jumper",
-  "version": "1.0.0",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-jumper",
-      "version": "1.0.0",
+      "version": "2.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,19 @@
             "type": "string"
           },
           "description": "global components prefix config"
+        },
+        "vue-jumper.rules": {
+          "type": "array",
+          "default": [
+            {
+              "prefix": "*",
+              "searchPattern": {
+                "include": "**/$1",
+                "exclude": "**/{node_modules,build,dist}"
+              }
+            }
+          ],
+          "description": "component jump and doc rules"
         }
       }
     }

--- a/src/JumperFileDefinitionProvider.ts
+++ b/src/JumperFileDefinitionProvider.ts
@@ -2,17 +2,18 @@
  * @Author: atdow
  * @Date: 2017-08-21 14:59:59
  * @LastEditors: null
- * @LastEditTime: 2023-11-14 20:47:46
+ * @LastEditTime: 2024-02-20 19:05:41
  * @Description: file description
  */
 import * as vscode from 'vscode'
 const util = require('./util')
 const fs = require('fs')
-import { IAliasConfigsItem, ILineInfo } from './types'
+import { IAliasConfigsItem, ILineInfo, IRule } from './types'
 
 export default class JumperFileDefinitionProvider implements vscode.DefinitionProvider {
   aliasConfigs: IAliasConfigsItem[] = []
   globalComponentsPrefixConfigs: string[] = []
+  rules: IRule[] = []
   possibleFileNamesMap: { [key: string]: string[] } = {
     vue: ['.vue', '/index.vue'],
     js: ['.js', '/index.js'],
@@ -21,7 +22,15 @@ export default class JumperFileDefinitionProvider implements vscode.DefinitionPr
     tsx: ['.tsx', '/index.tsx']
   }
 
-  constructor(aliasConfigs: string[] = [], globalComponentsPrefixConfigs: string[] = []) {
+  constructor({
+    aliasConfigs = [],
+    globalComponentsPrefixConfigs = [],
+    rules = []
+  }: {
+    aliasConfigs: string[]
+    globalComponentsPrefixConfigs: string[]
+    rules: IRule[]
+  }) {
     aliasConfigs.forEach((aliasConfigsItem) => {
       try {
         const aliasConfigsItemArr: string[] = aliasConfigsItem.split(':')
@@ -35,7 +44,9 @@ export default class JumperFileDefinitionProvider implements vscode.DefinitionPr
         // console.log("aliasConfigs:", aliasConfigs);
       }
     })
+
     this.globalComponentsPrefixConfigs = globalComponentsPrefixConfigs
+    this.rules = rules
   }
 
   async judeLineType(line: String, keyword: string, document: vscode.TextDocument): Promise<ILineInfo> {
@@ -215,7 +226,14 @@ export default class JumperFileDefinitionProvider implements vscode.DefinitionPr
   }
 
   searchFilePath(fileName: String): Thenable<vscode.Uri[]> {
-    return vscode.workspace.findFiles(`**/${fileName}`, '**/node_modules') // Returns promise
+    const componentName = fileName as string
+    // 查找匹配的规则
+    const matchedRule =
+      this.rules.find((rule) => componentName.startsWith(rule.prefix)) || this.rules.find((rule) => rule.prefix === '*')
+
+    const pattern = matchedRule.searchPattern
+
+    return vscode.workspace.findFiles(pattern.include.replace('$1', componentName), pattern.exclude)
   }
 
   provideDefinition(
@@ -226,7 +244,7 @@ export default class JumperFileDefinitionProvider implements vscode.DefinitionPr
     let filePaths: vscode.Uri[] = []
     return this.getComponentName(position, document).then((componentNames) => {
       // console.log("componentNames:", componentNames);
-      const searchPathActions: Thenable<vscode.Uri[]>[] = componentNames.map(this.searchFilePath)
+      const searchPathActions: Thenable<vscode.Uri[]>[] = componentNames.map((name) => this.searchFilePath(name))
       const searchPromises = Promise.all(searchPathActions) // pass array of promises
       return searchPromises.then(
         (paths) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,8 @@
 'use strict'
 import * as vscode from 'vscode'
 import JumperFileDefinitionProvider from './JumperFileDefinitionProvider'
+import { IRule } from './types'
+import provideVueComponentHover from './provideVueComponentHover'
 
 const languageConfiguration: vscode.LanguageConfiguration = {
   wordPattern: /(\w+((-\w+)+)?)/
@@ -18,12 +20,37 @@ export function activate(context: vscode.ExtensionContext) {
   const supportedLanguages = ['vue']
   const aliasConfigs = configParams.get('aliasConfigs') as Array<string>
   const globalComponentsPrefixConfigs = configParams.get('globalComponentsPrefixConfigs') as Array<string>
+  const rules = configParams.get('rules') as IRule[]
+
+  // 获取默认搜索模式
+  const defaultRule = rules.find((rule) => rule.prefix === '*')
+
+  // 确保有默认搜索模式
+  if (!defaultRule) {
+    rules.push({
+      prefix: '*',
+      searchPattern: {
+        include: '**/$1',
+        exclude: '**/{node_modules,build,dist}'
+      }
+    })
+  }
 
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider(
       supportedLanguages,
-      new JumperFileDefinitionProvider(aliasConfigs, globalComponentsPrefixConfigs)
+      new JumperFileDefinitionProvider({
+        aliasConfigs,
+        globalComponentsPrefixConfigs,
+        rules
+      })
     )
+  )
+
+  context.subscriptions.push(
+    vscode.languages.registerHoverProvider(supportedLanguages, {
+      provideHover: (document, position) => provideVueComponentHover(document, position, rules)
+    })
   )
 
   /* Provides way to get selected text even if there is dash

--- a/src/provideVueComponentHover.ts
+++ b/src/provideVueComponentHover.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode'
+import { IRule } from './types'
+
+export default function provideVueComponentHover(document, position, rules: IRule[]) {
+  const componentName = document.getText(document.getWordRangeAtPosition(position))
+
+  // 遍历配置查找匹配的组件前缀
+  for (const rule of rules) {
+    if (componentName.startsWith(rule.prefix) && rule.docUrl) {
+      const url = rule.docUrl.replace('{name}', componentName)
+
+      return new vscode.Hover(`See：${url}`)
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,3 +15,14 @@ export interface ILineInfo {
   path: string
   originPath: string
 }
+
+export interface ISearchPattern {
+  include: string
+  exclude: string
+}
+
+export interface IRule {
+  prefix: string
+  docUrl?: string
+  searchPattern: ISearchPattern
+}


### PR DESCRIPTION
新增 `vue-jumper.rules` 配置，可以自定义组件的查找规则和文档链接。每条规则可以包含组件前缀匹配、文件查找模式和文档地址：

```json
"vue-jumper.rules": [
  {
    "prefix": "uni-",
    "docUrl": "https://uniapp.dcloud.net.cn/component/uniui/{name}.html", // hover 时出现的文档地址
    "searchPattern": {
      "include": "**/node_modules/@dcloudio/uni-ui/lib/$1",
      "exclude": ""
    }
  },
  {
    "prefix": "u-",
    "docUrl": "https://uviewui.com/components/{name}.html",
    "searchPattern": {
      "include": "**/node_modules/uview-ui/components/$1",
      "exclude": ""
    }
  },
  // 默认配置，应放在最后
  {
    "prefix": "*",
    "searchPattern": {
      "include": "**/$1",
      "exclude": "**/{node_modules,build,dist}" // 这里是个 breaking change
    }
  }
]
```