### PR TITLE
fix: possibleFileNames 重复添加导致出现多个 path 的问题

### DIFF
--- a/src/JumperFileDefinitionProvider.ts
+++ b/src/JumperFileDefinitionProvider.ts
@@ -206,7 +206,6 @@ export default class JumperFileDefinitionProvider implements vscode.DefinitionPr
             })
           }
         })
-        possibleFileNames.push(path)
         return possibleFileNames
       })
       .catch(() => {

--- a/src/JumperFileDefinitionProvider.ts
+++ b/src/JumperFileDefinitionProvider.ts
@@ -198,14 +198,22 @@ export default class JumperFileDefinitionProvider implements vscode.DefinitionPr
           })
           return possibleFileNames
         }
-        // TODO 下面这里可能会和vscode自带的查找逻辑有重复，可以做优化
-        Object.keys(this.possibleFileNamesMap).forEach((key) => {
-          if (!path.endsWith(`.${key}`)) {
+        // 检查 path 是否以任何一个 possibleFileNamesMap 的后缀结尾
+        const hasMatchedExtension = Object.keys(this.possibleFileNamesMap).some(
+          (key) => path.endsWith(`.${key}`) || path.endsWith(`/index.${key}`)
+        )
+
+        if (hasMatchedExtension) {
+          // 如果匹配到后缀，只添加 path 本身
+          possibleFileNames.push(path)
+        } else {
+          // 否则添加所有可能的后缀组合
+          Object.keys(this.possibleFileNamesMap).forEach((key) => {
             this.possibleFileNamesMap[key].forEach((item) => {
               possibleFileNames.push(path + item)
             })
-          }
-        })
+          })
+        }
         return possibleFileNames
       })
       .catch(() => {


### PR DESCRIPTION
修复尝试跳转到显式导入的组件时会出现两个定义。possibleFileNames.push(path) 应该是不需要的的，因为已经有 path 说明能跳转，再多 push 一个就重复了